### PR TITLE
Bump dependency versions

### DIFF
--- a/servant-yaml.cabal
+++ b/servant-yaml.cabal
@@ -31,10 +31,10 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      base        >=4.9      && <4.14
-    , bytestring  >=0.10.8.1 && <0.11
+      base        >=4.9      && <5
+    , bytestring  >=0.10.8.1 && <0.12
     , http-media  >=0.7.1.3  && <0.9
-    , servant     >=0.15     && <0.18
+    , servant     >=0.15     && <0.20
     , yaml        >=0.11     && <0.12
   exposed-modules:
       Servant.Yaml
@@ -53,9 +53,9 @@ test-suite example
     , servant
     , yaml
     , servant-yaml
-    , servant-server >=0.15     && <0.18
-    , base-compat    >=0.10.5   && <0.12
-    , aeson          >=1.4.1.0  && <1.5
+    , servant-server >=0.15     && <0.20
+    , base-compat    >=0.10.5   && <0.13
+    , aeson          >=1.4.1.0  && <3
     , wai            >=3.2.1.2  && <3.3
     , warp           >=3.2.25   && <3.4
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,0 @@
-stack-lts-2.yaml


### PR DESCRIPTION
I tested that this package can be built with ghc-8.10.7 and ghc-9.2.4. I didn't attempt to fix warnings but did see these (and would be happy to fix them too):

```
> cabal build all --enable-tests --enable-benchmarks
...
src/Servant/Yaml.hs:1:14: warning: [-Wdeprecated-flags]
    -XAutoDeriveTypeable is deprecated: Typeable instances are
     created automatically for all types since GHC 8.2.
  |
1 | {-# LANGUAGE AutoDeriveTypeable    #-}
  |              ^^^^^^^^^^^^^^^^^^
...
example/Main.hs:14:1: warning: [-Wunused-imports]
    The import of ‘Network.Wai’ is redundant
      except perhaps to import instances from ‘Network.Wai’
    To import instances alone, use: import Network.Wai()
   |
14 | import           Network.Wai
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```